### PR TITLE
fix: SDP-14052: align registry mirrors CLI option

### DIFF
--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -25,7 +25,7 @@ jobs:
         mkdir -p $HOME/.docker
         echo "$DOCKERCONFIGJSON" > $HOME/.docker/config.json
     - name: docker build and publish
-      uses: cloudbees-io/kaniko@v1
+      uses: ./
       with:
         destination: registry.saas-dev.beescloud.com/staging/kaniko-action:${{ cloudbees.scm.sha }}${{ cloudbees.scm.branch == 'main' && ',registry.saas-dev.beescloud.com/staging/kaniko-action:0.0.5,registry.saas-dev.beescloud.com/staging/kaniko-action:latest' || '' }}
         labels: maintaner=sdp-pod-3,email=engineering@cloudbees.io

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,6 @@ func init() {
 	cmd.Flags().StringVar(&cfg.Dockerfile, "dockerfile", "", "Dockerfile is the path to the Dockerfile to build")
 	cmd.Flags().StringVar(&cfg.DockerContext, "context", "", "Context is the path to the build context")
 	cmd.Flags().StringVar(&cfg.Destination, "destination", "", "Destination is the destination of the built image")
-	cmd.Flags().StringVar(&cfg.RegistryMirrors, "registryMirrors", "", "Registry mirrors to find images")
-	cmd.Flags().BoolVar(&cfg.SkipDefaultRegistryFallback, "skipDefaultRegistryFallback", false, "Fail if image is not found on registry mirrors")
+	cmd.Flags().StringVar(&cfg.RegistryMirrors, "registry-mirrors", "", "Registry mirrors to find images")
+	cmd.Flags().BoolVar(&cfg.SkipDefaultRegistryFallback, "skip-default-registry-fallback", false, "Fail if image is not found on registry mirrors")
 }


### PR DESCRIPTION
... name with Action input name. Same for the skip-default-registry-fallback input.

Also, makes the workflow test the Action on the main branch against the main branch again instead of testing the main branch against the v1 release of the Action.

This is a follow-up of #12 and #13