### PR TITLE
feat: SDP-15566: bump kaniko 1.22.0 container image

### DIFF
--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: docker build and publish
       uses: cloudbees-io/kaniko@v1
       with:
-        destination: ${{ vars.STAGING_DOCKER_REGISTRY }}/staging/kaniko-action:${{ cloudbees.scm.sha }}${{ cloudbees.scm.branch == 'main' && format(',{0}/staging/kaniko-action:0.0.7,{0}/staging/kaniko-action:latest', vars.STAGING_DOCKER_REGISTRY)  || format(',{0}/staging/kaniko-action:{1}', vars.STAGING_DOCKER_REGISTRY, cloudbees.version) }}
+        destination: ${{ vars.STAGING_DOCKER_REGISTRY }}/staging/kaniko-action:${{ cloudbees.scm.sha }}${{ cloudbees.scm.branch == 'main' && format(',{0}/staging/kaniko-action:0.0.8,{0}/staging/kaniko-action:latest', vars.STAGING_DOCKER_REGISTRY)  || format(',{0}/staging/kaniko-action:{1}', vars.STAGING_DOCKER_REGISTRY, cloudbees.version) }}
         labels: maintaner=sdp-pod-3,email=engineering@cloudbees.io
         context: ${{ cloudbees.workspace }}
   

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /usr/local/bin/kaniko-action main.go
 
-FROM gcr.io/kaniko-project/executor:v1.20.1
+FROM gcr.io/kaniko-project/executor:v1.22.0
 
 COPY --from=build /usr/local/bin/kaniko-action /usr/local/bin/kaniko-action
 


### PR DESCRIPTION
This is particularly to include the [fix](https://github.com/GoogleContainerTools/kaniko/pull/3051) allowing the `--registry-mirror` URL to contain a path.