### PR TITLE
CBP-7671: Removed temp input parameter 

### DIFF
--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -48,11 +48,6 @@ inputs:
     default: info
     description: >
       Log level verbosity - panic, fatal, error, warn, info, debug, trace
-  send-artifact-info:
-    default: 'true'
-    description: >
-      If set, artifact info is sent to Cloudbees Platform. Default set to true.
-      Type: Boolean
 
 outputs:
   digest:
@@ -94,7 +89,6 @@ runs:
           --skip-default-registry-fallback="${{ inputs.skip-default-registry-fallback }}"
           --verbosity "${{ inputs.verbosity }}"
           --target "${{ inputs.target }}"
-          --send-artifact-info="${{ inputs.send-artifact-info }}"
           ${{ inputs.tar-path && format('--tar-path "{0}"', inputs.tar-path) || '' }}
       env:
         DOCKER_CONFIG: ${{ cloudbees.home }}/.docker

--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -82,7 +82,6 @@ jobs:
         registry-mirrors: 020229604682.dkr.ecr.us-east-1.amazonaws.com/docker-hub
         verbosity: debug
         tar-path: ${{ cloudbees.home }}/image.tar
-        send-artifact-info: 'true'
 
     - name: Check test image
       uses: docker://alpine:3.18

--- a/action.yml
+++ b/action.yml
@@ -48,11 +48,6 @@ inputs:
     default: info
     description: >
       Log level verbosity - panic, fatal, error, warn, info, debug, trace
-  send-artifact-info:
-    default: 'true'
-    description: >
-      If set, artifact info is sent to Cloudbees Platform. Default set to true.
-      Type: Boolean
 
 outputs:
   digest:
@@ -94,7 +89,6 @@ runs:
           --skip-default-registry-fallback="${{ inputs.skip-default-registry-fallback }}"
           --verbosity "${{ inputs.verbosity }}"
           --target "${{ inputs.target }}"
-          --send-artifact-info="${{ inputs.send-artifact-info }}"
           ${{ inputs.tar-path && format('--tar-path "{0}"', inputs.tar-path) || '' }}
       env:
         DOCKER_CONFIG: ${{ cloudbees.home }}/.docker

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,5 +50,4 @@ func init() {
 	cmd.Flags().StringVar(&cfg.Verbosity, "verbosity", "debug", "Verbosity level of the Kaniko executor")
 	cmd.Flags().StringVar(&cfg.Target, "target", "", "Target stage to build in a multi-stage Dockerfile")
 	cmd.Flags().StringVar(&cfg.TarPath, "tar-path", "", "Path to save the image tar file (optional). If set, the image will be saved as a tar file.")
-	cmd.Flags().BoolVar(&cfg.SendArtifactInfo, "send-artifact-info", false, "If set, artifact info is sent to Cloudbees Platform. Default set to false")
 }

--- a/internal/kaniko/execute.go
+++ b/internal/kaniko/execute.go
@@ -66,7 +66,7 @@ func (k *Config) Run(ctx context.Context) (err error) {
 		}
 	}
 
-	fmt.Printf("Saving artifact information for the pushed images\n")
+	fmt.Printf("Saving artifact information for the pushed images...\n")
 	destinations := k.processDestinations()
 	err = k.createArtifactInfo(destinations)
 	if err != nil {

--- a/internal/kaniko/execute.go
+++ b/internal/kaniko/execute.go
@@ -66,13 +66,11 @@ func (k *Config) Run(ctx context.Context) (err error) {
 		}
 	}
 
-	fmt.Printf("Sending artifact information for the images to CloudBees Platform\n")
+	fmt.Printf("Saving artifact information for the pushed images\n")
 	destinations := k.processDestinations()
 	err = k.createArtifactInfo(destinations)
 	if err != nil {
-		log.Printf("WARN: failed to send artifact information: %v", err)
-	} else {
-		fmt.Printf("Sent artifact information for %d images\n", len(destinations))
+		log.Printf("WARN: failed to save artifact information: %v", err)
 	}
 	return nil
 }
@@ -114,7 +112,7 @@ func (k *Config) createArtifactInfo(destinations []string) error {
 
 	for _, destination := range destinations {
 		destination = strings.TrimSpace(destination)
-		fmt.Printf("Sending artifact information for image: %v\n", destination)
+		fmt.Printf("Saving artifact information for image %v\n", destination)
 
 		artifactInfo, err := k.buildCreateArtifactInfoRequest(destination, runId, runAttempt)
 		if err != nil {
@@ -147,6 +145,8 @@ func (k *Config) createArtifactInfo(destinations []string) error {
 
 		if resp.StatusCode != 200 {
 			return fmt.Errorf("request failed: \nPOST %s\nHTTP/%d %s\n", requestURL, resp.StatusCode, resp.Status)
+		} else {
+			fmt.Printf("Saved artifact information for image %v\n", destination)
 		}
 	}
 	return nil

--- a/internal/kaniko/execute.go
+++ b/internal/kaniko/execute.go
@@ -66,13 +66,13 @@ func (k *Config) Run(ctx context.Context) (err error) {
 		}
 	}
 
-	fmt.Printf("Sending artifact information for the pushed images to CloudBees Platform")
+	fmt.Printf("Sending artifact information for the images to CloudBees Platform\n")
 	destinations := k.processDestinations()
 	err = k.createArtifactInfo(destinations)
 	if err != nil {
 		log.Printf("WARN: failed to send artifact information: %v", err)
 	} else {
-		fmt.Printf("Sent artifact information for %d images", len(destinations))
+		fmt.Printf("Sent artifact information for %d images\n", len(destinations))
 	}
 	return nil
 }

--- a/internal/kaniko/execute_test.go
+++ b/internal/kaniko/execute_test.go
@@ -545,7 +545,7 @@ func Test_createArtifactInfo(t *testing.T) {
 		}
 
 		err := c.createArtifactInfo(destinations)
-		require.EqualError(t, err, "failed to send artifact info to CloudBees Platform because of missing CLOUDBEES_API_URL environment variable")
+		require.EqualError(t, err, "missing CLOUDBEES_API_URL environment variable")
 	})
 
 	t.Run("CLOUDBEES_API_TOKEN is nil", func(t *testing.T) {
@@ -566,7 +566,7 @@ func Test_createArtifactInfo(t *testing.T) {
 		}
 
 		err := c.createArtifactInfo(destinations)
-		require.EqualError(t, err, "failed to send artifact info to CloudBees Platform because of missing CLOUDBEES_API_TOKEN environment variable")
+		require.EqualError(t, err, "missing CLOUDBEES_API_TOKEN environment variable")
 	})
 
 	t.Run("CLOUDBEES_RUN_ID is empty", func(t *testing.T) {
@@ -587,7 +587,7 @@ func Test_createArtifactInfo(t *testing.T) {
 		}
 
 		err := c.createArtifactInfo(destinations)
-		require.EqualError(t, err, "failed to send artifact info to CloudBees Platform because of missing CLOUDBEES_RUN_ID environment variable")
+		require.EqualError(t, err, "missing CLOUDBEES_RUN_ID environment variable")
 	})
 
 	t.Run("CLOUDBEES_RUN_ATTEMPT is empty", func(t *testing.T) {
@@ -608,7 +608,7 @@ func Test_createArtifactInfo(t *testing.T) {
 		}
 
 		err := c.createArtifactInfo(destinations)
-		require.EqualError(t, err, "failed to send artifact info because of missing CLOUDBEES_RUN_ATTEMPT environment variable")
+		require.EqualError(t, err, "missing CLOUDBEES_RUN_ATTEMPT environment variable")
 	})
 
 	t.Run("create - Success", func(t *testing.T) {
@@ -671,7 +671,7 @@ func Test_createArtifactInfo(t *testing.T) {
 		}
 
 		err := c.createArtifactInfo(destinations)
-		require.EqualErrorf(t, err, "failed to create artifact info: \nPOST https://cloudbees.io/v2/workflows/runs/artifactinfos\nHTTP/400 \n",
+		require.EqualErrorf(t, err, "request failed: \nPOST https://cloudbees.io/v2/workflows/runs/artifactinfos\nHTTP/400 \n",
 			"failed to create artifact info: \nPOST %s\nHTTP/%d %s\n",
 			"https://cloudbees.io/v2/workflows/runs/artifactinfos", 400, "Bad Request")
 	})

--- a/internal/kaniko/types.go
+++ b/internal/kaniko/types.go
@@ -22,8 +22,6 @@ type Config struct {
 	Target string `json:"target,omitempty"`
 	// TarPath is an optional path to save the image as a tar file.
 	TarPath string `json:"tar-path,omitempty"`
-	// SendArtifactInfo sets whether the published docker image artifact info should be sent to Cloudbees Platform
-	SendArtifactInfo bool `json:"sendArtifactInfo,omitempty"`
 
 	client HTTPClient
 }


### PR DESCRIPTION
Removed temp input parameter `send-artifact-info` and cleaned log messages around sending artifact information to the platform