### PR TITLE
CBP-20707 - Update kaniko action with commit details

### DIFF
--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -50,15 +50,15 @@ inputs:
       Log level verbosity - panic, fatal, error, warn, info, debug, trace
   commit:
     description:
-      The commit ID from the source repository, used when registering the build artifact in the CloudBees platform.
+      The commit ID from the source repository, used when registering the build artifact in CloudBees platform.
     default: ${{ cloudbees.scm.sha }}
   repository-url:
     description: >
-      The clone URL of the source repository, used when registering the build artifact in the CloudBees platform.
+      The clone URL of the source repository, used when registering the build artifact in CloudBees platform.
     default: ${{ cloudbees.scm.repositoryUrl }}
   ref:
     description: >
-      The ref or branch of the source repository, used when registering the build artifact in the CloudBees platform.
+      The ref or branch of the source repository, used when registering the build artifact in CloudBees platform.
     default: ${{ cloudbees.scm.ref }}
 
 outputs:

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -48,6 +48,20 @@ inputs:
     default: info
     description: >
       Log level verbosity - panic, fatal, error, warn, info, debug, trace
+  commit:
+    description:
+      The commit ID from the source repository.
+  repository-url:
+    description: >
+      The clone URL of the repository.
+  ref:
+    description: >
+      The ref or branch of the checked-out repository.
+  no-commit:
+    description: >
+      If a commit is not supplied and no-commit is set, the action will not use the default commit ID from the workflow.
+      Type: Boolean
+    default: 'false'
 
 outputs:
   digest:
@@ -103,3 +117,7 @@ runs:
         CLOUDBEES_API_TOKEN: ${{ cloudbees.api.token }}
         CLOUDBEES_RUN_ID: ${{ cloudbees.run_id }}
         CLOUDBEES_RUN_ATTEMPT: ${{ cloudbees.run_attempt }}
+        INPUT_REPOSITORY_URL: ${{ inputs.repository-url }}
+        INPUT_COMMIT: ${{ inputs.commit }}
+        INPUT_REF: ${{ inputs.ref }}
+        INPUT_NO_COMMIT: ${{ inputs.no-commit }}

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -53,14 +53,14 @@ inputs:
       The commit ID from the source repository. It is used when registering the build artifact in the CloudBees platform.
   repository-url:
     description: >
-      The clone URL of the repository. it is used when registering the build artifact in the CloudBees platform.
+      The clone URL of the source repository. It is used when registering the build artifact in the CloudBees platform.
   ref:
     description: >
-      The ref or branch of the checked-out repository. It is used when registering the build artifact in the CloudBees platform.
+      The ref or branch of the source repository. It is used when registering the build artifact in the CloudBees platform.
   no-commit:
     description: >
-      If a commit is not supplied and no-commit is set to true, the action will not use the default commit ID from the workflow.
-      The commit details will be empty when registering the build artifact in the CloudBees platform.
+      If `commit` is not supplied and `no-commit: false` is specified, the default commit ID from the workflow will be used when registering the artifact.
+      If a commit is not supplied and `no-commit: true` is specified, the action does *not* use the default commit ID from the workflow.
       Type: Boolean
     default: 'false'
 

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -50,19 +50,16 @@ inputs:
       Log level verbosity - panic, fatal, error, warn, info, debug, trace
   commit:
     description:
-      The commit ID from the source repository. It is used when registering the build artifact in the CloudBees platform.
+      The commit ID from the source repository, used when registering the build artifact in the CloudBees platform.
+    default: ${{ cloudbees.scm.sha }}
   repository-url:
     description: >
-      The clone URL of the source repository. It is used when registering the build artifact in the CloudBees platform.
+      The clone URL of the source repository, used when registering the build artifact in the CloudBees platform.
+    default: ${{ cloudbees.scm.repositoryUrl }}
   ref:
     description: >
-      The ref or branch of the source repository. It is used when registering the build artifact in the CloudBees platform.
-  no-commit:
-    description: >
-      If `commit` is not supplied and `no-commit: false` is specified, the default commit ID from the workflow will be used when registering the artifact.
-      If a commit is not supplied and `no-commit: true` is specified, the action does *not* use the default commit ID from the workflow.
-      Type: Boolean
-    default: 'false'
+      The ref or branch of the source repository, used when registering the build artifact in the CloudBees platform.
+    default: ${{ cloudbees.scm.ref }}
 
 outputs:
   digest:
@@ -121,4 +118,3 @@ runs:
         INPUT_REPOSITORY_URL: ${{ inputs.repository-url }}
         INPUT_COMMIT: ${{ inputs.commit }}
         INPUT_REF: ${{ inputs.ref }}
-        INPUT_NO_COMMIT: ${{ inputs.no-commit }}

--- a/.cloudbees/testing/action.yml
+++ b/.cloudbees/testing/action.yml
@@ -50,16 +50,17 @@ inputs:
       Log level verbosity - panic, fatal, error, warn, info, debug, trace
   commit:
     description:
-      The commit ID from the source repository.
+      The commit ID from the source repository. It is used when registering the build artifact in the CloudBees platform.
   repository-url:
     description: >
-      The clone URL of the repository.
+      The clone URL of the repository. it is used when registering the build artifact in the CloudBees platform.
   ref:
     description: >
-      The ref or branch of the checked-out repository.
+      The ref or branch of the checked-out repository. It is used when registering the build artifact in the CloudBees platform.
   no-commit:
     description: >
-      If a commit is not supplied and no-commit is set, the action will not use the default commit ID from the workflow.
+      If a commit is not supplied and no-commit is set to true, the action will not use the default commit ID from the workflow.
+      The commit details will be empty when registering the build artifact in the CloudBees platform.
       Type: Boolean
     default: 'false'
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,6 +5,12 @@ Kaniko builds images inside a container or Kubernetes cluster.
 This action also publishes the image and tag names to the platform for artifact traceability purposes. 
 View build artifact information in *Build artifacts* of *Run details* and in *Artifacts*.
 
+== Automatic artifact data reporting
+
+This action link:https://docs.cloudbees.com/docs/cloudbees-platform/latest/workflows/artifacts[reports artifact-related data] to the workflow run for artifact traceability purposes.
+
+Do not include the link:https://github.com/cloudbees-io/register-build-artifact[`register-build-artifact` action] for the same artifact version, as the resulting run would register duplicate artifact entries to CloudBees platform.
+
 == Prerequisites
 
 To authenticate with the Docker registry, you must have a Docker config file in the `${HOME}/.docker/config.json` path.
@@ -103,22 +109,23 @@ Default is `info`.
 | `commit`
 | String
 | No
-| The commit ID from the source repository.
+| The commit ID from the source repository. It is used when registering the build artifact in the CloudBees platform.
 
 | `repository-url`
 | String
 | No
-| The clone URL of the repository.
+| The clone URL of the source repository. It is used when registering the build artifact in the CloudBees platform.
 
 | `ref`
 | String
 | No
-| The ref or branch of the checked-out repository.
+| The ref or branch of the source repository. It is used when registering the build artifact in the CloudBees platform.
 
 | `no-commit`
 | Boolean
 | No
-| If a commit is not supplied and no-commit is set to 'true', the action will not use the default commit ID from the workflow.
+| If `commit` is not supplied and `no-commit: false` is specified, the default commit ID from the workflow will be used when registering the artifact.
+If a commit is not supplied and `no-commit: true` is specified, the action does *not* use the default commit ID from the workflow.
 The default is `false`.
 
 |===
@@ -135,27 +142,23 @@ The default is `false`.
 
 | `digest`
 | String
-| Image digest (image ID)
+| The image digest.
 
 | `tag`
 | String
-| Tag of the first pushed image
+| The tag of the first pushed image.
 
 | `tag-digest`
 | String
-| Tag of the first specified destination along with the image digest.
-Please note that this format is not part of the OCI standard but supported by most container tools.
-Tools loading such an image reference ignore the tag but perform the lookup based on the image repository and digest only.
-The tag only serves as a hint for humans.
-Using this format guarantees that the image is continued to be used even when the tag was overwritten and prevents stale image caches on different nodes.
+| The tag of the first specified destination and the image digest, in a format not part of the OCI standard but supported by most container tools.
+Tools loading such an image reference ignore the tag, which serves as a hint for humans, but perform the lookup based on the image repository and digest only.
+Use this format to guarantee that the same image is used even if the tag has been overwritten, and to prevent stale image caches on different nodes.
 
 | `image`
 | String
-| Image reference of the first specified destination, including the image digest.
-Please note that this image reference format is not part of the OCI standard but supported by most container tools.
-Tools loading such an image reference ignore the tag but perform the lookup based on the image repository and digest only.
-The tag only serves as a hint for humans.
-Using this image reference format guarantees that the image is continued to be used even when the tag was overwritten and prevents stale image caches on different nodes.
+| Image reference of the first specified destination and the image digest, in a format not part of the OCI standard but supported by most container tools.
+Tools loading such an image reference ignore the tag, which serves as a hint for humans, but perform the lookup based on the image repository and digest only.
+Use this image reference format to guarantee that the same image is used even if the tag has been overwritten, and to prevent stale image caches on different nodes.
 
 | `artifact-ids`
 | JSON string
@@ -290,4 +293,4 @@ link:https://opensource.org/license/mit/[MIT license].
 == References
 
 * Learn more about link:https://docs.cloudbees.com/docs/cloudbees-platform/latest/actions[using actions in CloudBees workflows].
-* Learn about link:https://docs.cloudbees.com/docs/cloudbees-platform/latest/[the CloudBees platform].
+* Learn about link:https://docs.cloudbees.com/docs/cloudbees-platform/latest/[CloudBees platform].

--- a/README.adoc
+++ b/README.adoc
@@ -82,6 +82,11 @@ Formatted as a comma-separated list for passing multiple registries.
 If `registry-mirrors` is empty, this flag is ignored.
 Default is `false`.
 
+| `target`
+| String
+| No
+| Build a specific target stage in a multi-stage Dockerfile.
+
 | `tar-path`
 | String
 | No
@@ -95,6 +100,27 @@ To use this option, the image file must be in the TAR format.
 Accepted inputs are: `panic`, `fatal`, `error`, `warn`, `info`, `debug`, `trace`.
 Default is `info`.
 
+| `commit`
+| String
+| No
+| The commit ID from the source repository.
+
+| `repository-url`
+| String
+| No
+| The clone URL of the repository.
+
+| `ref`
+| String
+| No
+| The ref or branch of the checked-out repository.
+
+| `no-commit`
+| Boolean
+| No
+| If a commit is not supplied and no-commit is set to 'true', the action will not use the default commit ID from the workflow.
+The default is `false`.
+
 |===
 
 == Output
@@ -106,6 +132,30 @@ Default is `info`.
 | Output name
 | Data type
 | Description
+
+! `digest`
+| String
+| Image digest (image ID)
+
+| `tag`
+| String
+| Tag of the first pushed image
+
+| `tag-digest`
+| String
+| Tag of the first specified destination along with the image digest.
+Please note that this format is not part of the OCI standard but supported by most container tools.
+Tools loading such an image reference ignore the tag but perform the lookup based on the image repository and digest only.
+The tag only serves as a hint for humans.
+Using this format guarantees that the image is continued to be used even when the tag was overwritten and prevents stale image caches on different nodes.
+
+| `image`
+| String
+| Image reference of the first specified destination, including the image digest.
+Please note that this image reference format is not part of the OCI standard but supported by most container tools.
+Tools loading such an image reference ignore the tag but perform the lookup based on the image repository and digest only.
+The tag only serves as a hint for humans.
+Using this image reference format guarantees that the image is continued to be used even when the tag was overwritten and prevents stale image caches on different nodes.
 
 | `artifact-ids`
 | JSON string

--- a/README.adoc
+++ b/README.adoc
@@ -109,24 +109,20 @@ Default is `info`.
 | `commit`
 | String
 | No
-| The commit ID from the source repository. It is used when registering the build artifact in the CloudBees platform.
+| The commit ID from the source repository, used when registering the build artifact in the CloudBees platform.
+Default is `${{ cloudbees.scm.sha }}`.
 
 | `repository-url`
 | String
 | No
-| The clone URL of the source repository. It is used when registering the build artifact in the CloudBees platform.
+| The clone URL of the source repository, used when registering the build artifact in the CloudBees platform.
+Default is `${{ cloudbees.scm.repositoryUrl }}`.
 
 | `ref`
 | String
 | No
-| The ref or branch of the source repository. It is used when registering the build artifact in the CloudBees platform.
-
-| `no-commit`
-| Boolean
-| No
-| If `commit` is not supplied and `no-commit: false` is specified, the default commit ID from the workflow will be used when registering the artifact.
-If a commit is not supplied and `no-commit: true` is specified, the action does *not* use the default commit ID from the workflow.
-The default is `false`.
+| The ref or branch of the source repository, used when registering the build artifact in the CloudBees platform.
+Default is `${{ cloudbees.scm.ref }}`.
 
 |===
 

--- a/README.adoc
+++ b/README.adoc
@@ -133,7 +133,7 @@ The default is `false`.
 | Data type
 | Description
 
-! `digest`
+| `digest`
 | String
 | Image digest (image ID)
 

--- a/action.yml
+++ b/action.yml
@@ -50,15 +50,15 @@ inputs:
       Log level verbosity - panic, fatal, error, warn, info, debug, trace
   commit:
     description:
-      The commit ID from the source repository, used when registering the build artifact in the CloudBees platform.
+      The commit ID from the source repository, used when registering the build artifact in CloudBees platform.
     default: ${{ cloudbees.scm.sha }}
   repository-url:
     description: >
-      The clone URL of the source repository, used when registering the build artifact in the CloudBees platform.
+      The clone URL of the source repository, used when registering the build artifact in CloudBees platform.
     default: ${{ cloudbees.scm.repositoryUrl }}
   ref:
     description: >
-      The ref or branch of the source repository, used when registering the build artifact in the CloudBees platform.
+      The ref or branch of the source repository, used when registering the build artifact in CloudBees platform.
     default: ${{ cloudbees.scm.ref }}
 
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,20 @@ inputs:
     default: info
     description: >
       Log level verbosity - panic, fatal, error, warn, info, debug, trace
+  commit:
+    description:
+      The commit ID from the source repository.
+  repository-url:
+    description: >
+      The clone URL of the repository.
+  ref:
+    description: >
+      The ref or branch of the checked-out repository.
+  no-commit:
+    description: >
+      If a commit is not supplied and no-commit is set, the action will not use the default commit ID from the workflow.
+      Type: Boolean
+    default: 'false'
 
 outputs:
   digest:
@@ -103,3 +117,7 @@ runs:
         CLOUDBEES_API_TOKEN: ${{ cloudbees.api.token }}
         CLOUDBEES_RUN_ID: ${{ cloudbees.run_id }}
         CLOUDBEES_RUN_ATTEMPT: ${{ cloudbees.run_attempt }}
+        INPUT_REPOSITORY_URL: ${{ inputs.repository-url }}
+        INPUT_COMMIT: ${{ inputs.commit }}
+        INPUT_REF: ${{ inputs.ref }}
+        INPUT_NO_COMMIT: ${{ inputs.no-commit }}

--- a/action.yml
+++ b/action.yml
@@ -53,14 +53,14 @@ inputs:
       The commit ID from the source repository. It is used when registering the build artifact in the CloudBees platform.
   repository-url:
     description: >
-      The clone URL of the repository. it is used when registering the build artifact in the CloudBees platform.
+      The clone URL of the source repository. It is used when registering the build artifact in the CloudBees platform.
   ref:
     description: >
-      The ref or branch of the checked-out repository. It is used when registering the build artifact in the CloudBees platform.
+      The ref or branch of the source repository. It is used when registering the build artifact in the CloudBees platform.
   no-commit:
     description: >
-      If a commit is not supplied and no-commit is set to true, the action will not use the default commit ID from the workflow.
-      The commit details will be empty when registering the build artifact in the CloudBees platform.
+      If `commit` is not supplied and `no-commit: false` is specified, the default commit ID from the workflow will be used when registering the artifact.
+      If a commit is not supplied and `no-commit: true` is specified, the action does *not* use the default commit ID from the workflow.
       Type: Boolean
     default: 'false'
 

--- a/action.yml
+++ b/action.yml
@@ -50,19 +50,16 @@ inputs:
       Log level verbosity - panic, fatal, error, warn, info, debug, trace
   commit:
     description:
-      The commit ID from the source repository. It is used when registering the build artifact in the CloudBees platform.
+      The commit ID from the source repository, used when registering the build artifact in the CloudBees platform.
+    default: ${{ cloudbees.scm.sha }}
   repository-url:
     description: >
-      The clone URL of the source repository. It is used when registering the build artifact in the CloudBees platform.
+      The clone URL of the source repository, used when registering the build artifact in the CloudBees platform.
+    default: ${{ cloudbees.scm.repositoryUrl }}
   ref:
     description: >
-      The ref or branch of the source repository. It is used when registering the build artifact in the CloudBees platform.
-  no-commit:
-    description: >
-      If `commit` is not supplied and `no-commit: false` is specified, the default commit ID from the workflow will be used when registering the artifact.
-      If a commit is not supplied and `no-commit: true` is specified, the action does *not* use the default commit ID from the workflow.
-      Type: Boolean
-    default: 'false'
+      The ref or branch of the source repository, used when registering the build artifact in the CloudBees platform.
+    default: ${{ cloudbees.scm.ref }}
 
 outputs:
   digest:
@@ -121,4 +118,3 @@ runs:
         INPUT_REPOSITORY_URL: ${{ inputs.repository-url }}
         INPUT_COMMIT: ${{ inputs.commit }}
         INPUT_REF: ${{ inputs.ref }}
-        INPUT_NO_COMMIT: ${{ inputs.no-commit }}

--- a/action.yml
+++ b/action.yml
@@ -50,16 +50,17 @@ inputs:
       Log level verbosity - panic, fatal, error, warn, info, debug, trace
   commit:
     description:
-      The commit ID from the source repository.
+      The commit ID from the source repository. It is used when registering the build artifact in the CloudBees platform.
   repository-url:
     description: >
-      The clone URL of the repository.
+      The clone URL of the repository. it is used when registering the build artifact in the CloudBees platform.
   ref:
     description: >
-      The ref or branch of the checked-out repository.
+      The ref or branch of the checked-out repository. It is used when registering the build artifact in the CloudBees platform.
   no-commit:
     description: >
-      If a commit is not supplied and no-commit is set, the action will not use the default commit ID from the workflow.
+      If a commit is not supplied and no-commit is set to true, the action will not use the default commit ID from the workflow.
+      The commit details will be empty when registering the build artifact in the CloudBees platform.
       Type: Boolean
     default: 'false'
 

--- a/internal/kaniko/execute.go
+++ b/internal/kaniko/execute.go
@@ -246,14 +246,32 @@ func (k *Config) buildCreateArtifactInfoRequest(destination, imageRef, runId, ru
 			imageDigest = after
 		}
 	}
+
+	commit := ""
+	repositoryURL := ""
+	inputRef := ""
+	if os.Getenv("INPUT_COMMIT") != "" {
+		commit = os.Getenv("INPUT_COMMIT")
+		repositoryURL = os.Getenv("INPUT_REPOSITORY_URL")
+		inputRef = os.Getenv("INPUT_REF")
+	}
+	noCommit := false
+	if os.Getenv("INPUT_NO_COMMIT") == "true" {
+		noCommit = true
+	}
+
 	artInfo := CreateArtifactInfoMap{
-		"runId":       runId,
-		"run_attempt": runAttempt,
-		"name":        imgName,
-		"version":     imgVer,
-		"url":         destination,
-		"type":        "docker",
-		"digest":      imageDigest,
+		"runId":                 runId,
+		"run_attempt":           runAttempt,
+		"name":                  imgName,
+		"version":               imgVer,
+		"url":                   destination,
+		"type":                  "docker",
+		"digest":                imageDigest,
+		"commit.commit":         commit,
+		"commit.repository_url": repositoryURL,
+		"commit.ref":            inputRef,
+		"ignore_default_commit": noCommit,
 	}
 
 	return artInfo, nil

--- a/internal/kaniko/execute.go
+++ b/internal/kaniko/execute.go
@@ -259,11 +259,6 @@ func (k *Config) buildCreateArtifactInfoRequest(destination, imageRef, runId, ru
 	if os.Getenv("INPUT_NO_COMMIT") == "true" {
 		noCommit = true
 	}
-	//	commitMap := map[string]string{
-	//		"commit_id":      commit,
-	//		"repository_url": repositoryURL,
-	//		"ref":            inputRef,
-	//}
 
 	artInfo := CreateArtifactInfoMap{
 		"runId":       runId,

--- a/internal/kaniko/execute.go
+++ b/internal/kaniko/execute.go
@@ -259,6 +259,11 @@ func (k *Config) buildCreateArtifactInfoRequest(destination, imageRef, runId, ru
 	if os.Getenv("INPUT_NO_COMMIT") == "true" {
 		noCommit = true
 	}
+	commitMap := map[string]string{
+		"commit_id":      commit,
+		"repository_url": repositoryURL,
+		"ref":            inputRef,
+	}
 
 	artInfo := CreateArtifactInfoMap{
 		"runId":                 runId,
@@ -268,9 +273,7 @@ func (k *Config) buildCreateArtifactInfoRequest(destination, imageRef, runId, ru
 		"url":                   destination,
 		"type":                  "docker",
 		"digest":                imageDigest,
-		"commit.commit":         commit,
-		"commit.repository_url": repositoryURL,
-		"commit.ref":            inputRef,
+		"commit":                commitMap,
 		"ignore_default_commit": noCommit,
 	}
 

--- a/internal/kaniko/execute.go
+++ b/internal/kaniko/execute.go
@@ -247,18 +247,9 @@ func (k *Config) buildCreateArtifactInfoRequest(destination, imageRef, runId, ru
 		}
 	}
 
-	commit := ""
-	repositoryURL := ""
-	inputRef := ""
-	if os.Getenv("INPUT_COMMIT") != "" {
-		commit = os.Getenv("INPUT_COMMIT")
-		repositoryURL = os.Getenv("INPUT_REPOSITORY_URL")
-		inputRef = os.Getenv("INPUT_REF")
-	}
-	noCommit := false
-	if os.Getenv("INPUT_NO_COMMIT") == "true" {
-		noCommit = true
-	}
+	commit := os.Getenv("INPUT_COMMIT")
+	repositoryURL := os.Getenv("INPUT_REPOSITORY_URL")
+	inputRef := os.Getenv("INPUT_REF")
 
 	artInfo := CreateArtifactInfoMap{
 		"runId":       runId,
@@ -273,7 +264,6 @@ func (k *Config) buildCreateArtifactInfoRequest(destination, imageRef, runId, ru
 			"repository_url": repositoryURL,
 			"ref":            inputRef,
 		},
-		"ignore_default_commit": noCommit,
 	}
 
 	return artInfo, nil

--- a/internal/kaniko/execute.go
+++ b/internal/kaniko/execute.go
@@ -259,21 +259,25 @@ func (k *Config) buildCreateArtifactInfoRequest(destination, imageRef, runId, ru
 	if os.Getenv("INPUT_NO_COMMIT") == "true" {
 		noCommit = true
 	}
-	commitMap := map[string]string{
-		"commit_id":      commit,
-		"repository_url": repositoryURL,
-		"ref":            inputRef,
-	}
+	//	commitMap := map[string]string{
+	//		"commit_id":      commit,
+	//		"repository_url": repositoryURL,
+	//		"ref":            inputRef,
+	//}
 
 	artInfo := CreateArtifactInfoMap{
-		"runId":                 runId,
-		"run_attempt":           runAttempt,
-		"name":                  imgName,
-		"version":               imgVer,
-		"url":                   destination,
-		"type":                  "docker",
-		"digest":                imageDigest,
-		"commit":                commitMap,
+		"runId":       runId,
+		"run_attempt": runAttempt,
+		"name":        imgName,
+		"version":     imgVer,
+		"url":         destination,
+		"type":        "docker",
+		"digest":      imageDigest,
+		"commit": map[string]string{
+			"commit_id":      commit,
+			"repository_url": repositoryURL,
+			"ref":            inputRef,
+		},
 		"ignore_default_commit": noCommit,
 	}
 

--- a/internal/kaniko/execute_test.go
+++ b/internal/kaniko/execute_test.go
@@ -492,6 +492,37 @@ func Test_buildCreateArtifactInfoRequest(t *testing.T) {
 		require.Equal(t, "a0cb1b7ee330e2f1ecf0e7bb974e167f30c0bce6", artInfo["version"])
 		require.Equal(t, "sha256:cafebabebeef", artInfo["digest"])
 	})
+	t.Run("success - commit provided", func(t *testing.T) {
+		var c = Config{}
+		setOSEnv()
+		setCommitEnv()
+		destination := "ubuntu"
+
+		artInfo, err := c.buildCreateArtifactInfoRequest(destination, "ubuntu:latest@sha256:cafebabebeef", os.Getenv("CLOUDBEES_RUN_ID"), os.Getenv("CLOUDBEES_RUN_ATTEMPT"))
+		require.Nil(t, err)
+		require.NotNil(t, artInfo)
+		require.Equal(t, "ubuntu", artInfo["name"])
+		require.Equal(t, "latest", artInfo["version"])
+		require.Equal(t, "sha256:cafebabebeef", artInfo["digest"])
+		require.Equal(t, "17564567-e89b-12d3-a456-426614174000", artInfo["commit.commit"])
+		require.Equal(t, "https://github.com/cloudbees-io/kaniko", artInfo["commit.repository_url"])
+		require.Equal(t, "main", artInfo["commit.ref"])
+		require.Equal(t, false, artInfo["ignore_default_commit"])
+	})
+	t.Run("success - no commit true", func(t *testing.T) {
+		var c = Config{}
+		setOSEnv()
+		os.Setenv("INPUT_NO_COMMIT", "true")
+		destination := "ubuntu"
+
+		artInfo, err := c.buildCreateArtifactInfoRequest(destination, "ubuntu:latest@sha256:cafebabebeef", os.Getenv("CLOUDBEES_RUN_ID"), os.Getenv("CLOUDBEES_RUN_ATTEMPT"))
+		require.Nil(t, err)
+		require.NotNil(t, artInfo)
+		require.Equal(t, "ubuntu", artInfo["name"])
+		require.Equal(t, "latest", artInfo["version"])
+		require.Equal(t, "sha256:cafebabebeef", artInfo["digest"])
+		require.Equal(t, true, artInfo["ignore_default_commit"])
+	})
 
 }
 
@@ -500,6 +531,12 @@ func setOSEnv() {
 	os.Setenv("CLOUDBEES_API_TOKEN", "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUI")
 	os.Setenv("CLOUDBEES_RUN_ID", "123e4567-e89b-12d3-a456-426614174000")
 	os.Setenv("CLOUDBEES_RUN_ATTEMPT", "1")
+}
+
+func setCommitEnv() {
+	os.Setenv("INPUT_COMMIT", "17564567-e89b-12d3-a456-426614174000")
+	os.Setenv("INPUT_REPOSITORY_URL", "https://github.com/cloudbees-io/kaniko")
+	os.Setenv("INPUT_REF", "main")
 }
 
 type MockHTTPClient struct {

--- a/internal/kaniko/execute_test.go
+++ b/internal/kaniko/execute_test.go
@@ -508,23 +508,7 @@ func Test_buildCreateArtifactInfoRequest(t *testing.T) {
 		require.Equal(t, "17564567-e89b-12d3-a456-426614174000", commit["commit_id"])
 		require.Equal(t, "https://github.com/cloudbees-io/kaniko", commit["repository_url"])
 		require.Equal(t, "main", commit["ref"])
-		require.Equal(t, false, artInfo["ignore_default_commit"])
 	})
-	t.Run("success - no commit true", func(t *testing.T) {
-		var c = Config{}
-		setOSEnv()
-		os.Setenv("INPUT_NO_COMMIT", "true")
-		destination := "ubuntu"
-
-		artInfo, err := c.buildCreateArtifactInfoRequest(destination, "ubuntu:latest@sha256:cafebabebeef", os.Getenv("CLOUDBEES_RUN_ID"), os.Getenv("CLOUDBEES_RUN_ATTEMPT"))
-		require.Nil(t, err)
-		require.NotNil(t, artInfo)
-		require.Equal(t, "ubuntu", artInfo["name"])
-		require.Equal(t, "latest", artInfo["version"])
-		require.Equal(t, "sha256:cafebabebeef", artInfo["digest"])
-		require.Equal(t, true, artInfo["ignore_default_commit"])
-	})
-
 }
 
 func setOSEnv() {

--- a/internal/kaniko/execute_test.go
+++ b/internal/kaniko/execute_test.go
@@ -499,14 +499,15 @@ func Test_buildCreateArtifactInfoRequest(t *testing.T) {
 		destination := "ubuntu"
 
 		artInfo, err := c.buildCreateArtifactInfoRequest(destination, "ubuntu:latest@sha256:cafebabebeef", os.Getenv("CLOUDBEES_RUN_ID"), os.Getenv("CLOUDBEES_RUN_ATTEMPT"))
+		commit := artInfo["commit"].(map[string]string)
 		require.Nil(t, err)
 		require.NotNil(t, artInfo)
 		require.Equal(t, "ubuntu", artInfo["name"])
 		require.Equal(t, "latest", artInfo["version"])
 		require.Equal(t, "sha256:cafebabebeef", artInfo["digest"])
-		require.Equal(t, "17564567-e89b-12d3-a456-426614174000", artInfo["commit.commit"])
-		require.Equal(t, "https://github.com/cloudbees-io/kaniko", artInfo["commit.repository_url"])
-		require.Equal(t, "main", artInfo["commit.ref"])
+		require.Equal(t, "17564567-e89b-12d3-a456-426614174000", commit["commit_id"])
+		require.Equal(t, "https://github.com/cloudbees-io/kaniko", commit["repository_url"])
+		require.Equal(t, "main", commit["ref"])
 		require.Equal(t, false, artInfo["ignore_default_commit"])
 	})
 	t.Run("success - no commit true", func(t *testing.T) {


### PR DESCRIPTION
Update the cloudbees-io/kaniko action with commit, repository-url, ref inputs with defaults from workflow run context `cloudbees.scm.*`.