### PR TITLE
Bump golang to 1.26.4

### DIFF
--- a/.cloudbees/workflows/workflow.yaml
+++ b/.cloudbees/workflows/workflow.yaml
@@ -15,10 +15,10 @@ jobs:
   build:
     steps:
     - name: Get source code
-      uses: cloudbees-io/checkout@v1
+      uses: cloudbees-io/checkout@v2
 
     - name: Validate action
-      uses: docker://amazon/aws-cli:2.12.6
+      uses: docker://amazon/aws-cli:2.35.13
       run: |
         TESTING_SHA=$(cat .cloudbees/testing/action.yml | sha1sum)
         ORIGINAL_SHA=$(sed -e 's|docker://public.ecr.aws/l7o7z1g8/actions/|docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/|g' < action.yml | sha1sum)
@@ -28,7 +28,7 @@ jobs:
         fi
 
     - name: Unit tests
-      uses: docker://golang:1.26.2
+      uses: docker://golang:1.26.4
       run: |
         go test --cover ./...
 
@@ -70,7 +70,7 @@ jobs:
     needs: [build]
     steps:
     - name: Get source code
-      uses: cloudbees-io/checkout@v1
+      uses: cloudbees-io/checkout@v2
 
     - name: Login to AWS
       uses: cloudbees-io/configure-aws-credentials@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-alpine3.22 AS build
+FROM golang:1.26.4-alpine3.24 AS build
 WORKDIR /work
 COPY go.mod* go.sum* ./
 RUN go mod download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudbees-io/kaniko
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/cloudbees-io/registry-config v0.0.0-20251119202030-7513ed84c737

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudbees-io/kaniko
 
-go 1.26.4
+go 1.26.2
 
 require (
 	github.com/cloudbees-io/registry-config v0.0.0-20251119202030-7513ed84c737


### PR DESCRIPTION
Should clear up https://cloudbees.atlassian.net/browse/CBP-43845. Also bumps the checkout action to v2 and the AWS CLI to latest.